### PR TITLE
Feat: Added Leaderboard & Live stats Designs #47

### DIFF
--- a/packages/nextjs/app/assets/constants.ts
+++ b/packages/nextjs/app/assets/constants.ts
@@ -40,3 +40,73 @@ export const FLIPS = [
     icon: "/happy_coin.png",
   },
 ];
+
+export const LEADERBOARD = [
+  {
+    imageSrc: "/starkcade.png",
+    username: "User A",
+    amount: 10,
+    time: 8,
+    imageAlt: "User Avatar",
+  },
+  {
+    imageSrc: "/starkcade.png",
+    username: "User B",
+    amount: 5,
+    time: 3,
+    imageAlt: "User Avatar",
+  },
+  {
+    imageSrc: "/starkcade.png",
+    username: "User C",
+    amount: 2.5,
+    time: 2,
+    imageAlt: "User Avatar",
+  },
+];
+
+
+export const LIVE_STATS = [
+  {
+    imageSrc: "/starkcade.png",
+    username: "User X",
+    amount: 0.25,
+    time: 10,
+    imageAlt: "User Avatar",
+  },
+  {
+    imageSrc: "/starkcade.png",
+    username: "User Y",
+    amount: 5,
+    time: 12,
+    imageAlt: "User Avatar",
+  },
+  {
+    imageSrc: "/starkcade.png",
+    username: "User Z",
+    amount: 7.5,
+    time: 17,
+    imageAlt: "User Avatar",
+  },
+];
+
+export const CONNECTED_USERS = [
+  {
+    imageSrc: "/starkcade.png",
+    username: "User 1",
+    time: 4,
+    imageAlt: "User Avatar",
+  },
+  {
+    imageSrc: "/starkcade.png",
+    username: "User 2",
+    time: 7,
+    imageAlt: "User Avatar",
+  },
+  {
+    imageSrc: "/starkcade.png",
+    username: "User 3",
+    time: 10,
+    imageAlt: "User Avatar",
+  },
+];

--- a/packages/nextjs/app/leaderboard/_components/Leaderboard.tsx
+++ b/packages/nextjs/app/leaderboard/_components/Leaderboard.tsx
@@ -1,0 +1,123 @@
+"use client";
+import Image from "next/image";
+import { CONNECTED_USERS, LEADERBOARD, LIVE_STATS } from "~~/app/assets/constants";
+
+export default function Leaderboard() {
+  const handleButtonClick = () => {
+    console.log("GO BACK");
+  };
+  const handleRefreshClick = () => {
+    console.log("Refresh");
+  };
+
+  return (
+    <div className="relative flex justify-center items-center min-h-screen overflow-hidden w-full p-8 sm:p-12">
+      <div className="w-full grid grid-cols-12 gap-y-12 gap-x-0 md:gap-8 max-w-6xl">
+        {/* Leaderboard */}
+        <div className="w-auto md:w-full col-span-12 md:col-span-6 h-auto bg-[#ece6f0] rounded-[28px] py-[24px] px-[16px] lg:px-[24px]">
+          <h2 className="text-2xl mb-10 w-full text-gray-800">LEADERBOARD</h2>
+          <div className="space-y-1">
+            {LEADERBOARD.map((leaderboard, index) => (
+              <div
+                key={index}
+                className={`flex items-center justify-between pb-1  ${index < ((LEADERBOARD as unknown as array).length - 1) ? "border-b border-gray-400 " : ""}`}
+              >
+                <div className="flex items-center gap-2">
+                  <Image
+                    alt={leaderboard.imageAlt}
+                    src={leaderboard.imageSrc}
+                    width={48}
+                    height={48}
+                    className="w-8 flex-none rounded-full border border-yellow-500/50 h-auto"
+                  />
+                  <p className="text-gray-800 text-sm sm:text-md md:text-sm lg:text-md">
+                    <span className="font-bold">{leaderboard.username}</span>{" has won"}
+                    <span className="font-bold"> {leaderboard.amount}</span>{" STRK"}
+                  </p>
+                </div>
+                <p className="text-[#333] text-xs">{leaderboard.time} minutes ago</p>
+              </div>
+            ))}
+          </div>
+          <div className="mt-5 flex justify-end w-full">
+            <button
+              className="w-auto py-3 px-8 bg-yellow-500 text-black font-bold rounded-lg hover:bg-yellow-400 transition"
+              onClick={handleRefreshClick}
+            >
+              REFRESH
+            </button>
+          </div>
+        </div>
+        {/* Live Stats */}
+        <div className="w-auto md:w-full col-span-12 md:col-span-6 h-auto bg-[#ece6f0] rounded-[28px] py-[24px] px-[16px] lg:px-[24px]">
+          <h2 className="text-2xl mb-10 w-full text-gray-800">LIVE STATS</h2>
+          <div className="space-y-1">
+            {LIVE_STATS.map((livestat, index) => (
+              <div
+                key={index}
+                className={`flex items-center justify-between pb-1  ${index < ((LIVE_STATS as unknown as array).length - 1) ? "border-b border-gray-400 " : ""}`}
+              >
+                <div className="flex items-center gap-2">
+                  <Image
+                    alt={livestat.imageAlt}
+                    src={livestat.imageSrc}
+                    width={48}
+                    height={48}
+                    className="w-8 flex-none rounded-full border border-yellow-500/50 h-auto"
+                  />
+                  <p className="text-gray-800 text-sm sm:text-md md:text-sm lg:text-md">
+                    <span className="font-bold">{livestat.username}</span>{" just played"}
+                    <span className="font-bold"> {livestat.amount}</span>{" STRK"}
+                  </p>
+                </div>
+                <p className="text-[#333] text-xs">{livestat.time} minutes ago</p>
+              </div>
+            ))}
+          </div>
+          <div className="mt-5 flex justify-end w-full">
+            <button
+              className="w-auto py-3 px-8 bg-yellow-500 text-black font-bold rounded-lg hover:bg-yellow-400 transition"
+              onClick={handleRefreshClick}
+            >
+              REFRESH
+            </button>
+          </div>
+        </div>
+        {/* Connected Users */}
+        <div className="w-full md:col-start-3 md:col-end-11 col-span-12 md:col-span-8 h-auto bg-[#ece6f0] rounded-[28px] py-[24px] px-[16px] lg:px-[24px]">
+          <h2 className="text-2xl mb-10 w-full text-gray-800">CONNECTED USERS</h2>
+          <div className="space-y-1">
+            {CONNECTED_USERS.map((connected_user, index) => (
+              <div
+                key={index}
+                className={`flex items-center justify-between pb-1  ${index < ((CONNECTED_USERS as unknown as array).length - 1) ? "border-b border-gray-400 " : ""}`}
+              >
+                <div className="flex items-center gap-2">
+                  <Image
+                    alt={connected_user.imageAlt}
+                    src={connected_user.imageSrc}
+                    width={48}
+                    height={48}
+                    className="w-8 flex-none rounded-full border border-yellow-500/50 h-auto"
+                  />
+                  <p className="text-gray-800 text-sm sm:text-md md:text-sm lg:text-md">
+                    <span className="font-bold">{connected_user.username}</span>{" is live"}
+                  </p>
+                </div>
+                <p className="text-[#333] text-xs">{connected_user.time} minutes ago</p>
+              </div>
+            ))}
+          </div>
+          <div className="mt-5 flex justify-end w-full">
+            <button
+              className="w-full py-3 px-8 bg-yellow-500 text-black font-bold rounded-lg hover:bg-yellow-400 transition"
+              onClick={handleButtonClick}
+            >
+              GO BACK
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/nextjs/app/leaderboard/page.tsx
+++ b/packages/nextjs/app/leaderboard/page.tsx
@@ -1,0 +1,11 @@
+import Leaderboard from "./_components/Leaderboard";
+import type { NextPage } from "next";
+
+const Debug: NextPage = () => {
+  return (
+        <Leaderboard />
+  );
+};
+
+export default Debug;
+

--- a/packages/nextjs/app/profile/_components/ProfilePage.tsx
+++ b/packages/nextjs/app/profile/_components/ProfilePage.tsx
@@ -1,18 +1,73 @@
 "use client";
 
 import React from 'react'
+import Link from "next/link";
+import { ChevronDownIcon, ChevronRightIcon, CurrencyDollarIcon, CircleStackIcon, UsersIcon } from "@heroicons/react/24/solid";
+
 
 export const ProfilePage = () => {
     const [profileName, setProfileName] = React.useState('USER PROFILE');
     const [name, setName] = React.useState('');
+    const [profileDropdown, setProfileDropdown] = React.useState(false);
     // Add simple behavior to the ProfilePage component that allows users to save their profile name limited to frontend.
     const handleSave = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) =>{
         e.preventDefault();
         setProfileName(name);
         setName('');
     }
+    const handeProfileDropdownClick = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) =>{
+        e.preventDefault();
+        setProfileDropdown(!profileDropdown);
+    }
+    const PROFILE_LINKS = [
+        {name: "Transaction History", href: "#"},
+        {name: "Recent Flips", href: "#"},
+        {name: "Switch Account", href: "#"},
+        {name: "Leaderboard", href: "/leaderboard"},
+        {name: "Disconnect", href: "#"},
+    ];
     return (
         <div className="relative flex justify-center items-center min-h-screen text-white overflow-hidden">
+            <div className="w-full absolute p-8 right-0 flex flex-col space-y-1.5 items-end justify-end top-0">
+                <button  onClick={(event) => {
+                    handeProfileDropdownClick(event);
+                }} className="w-fit py-2 px-4 bg-yellow-500 text-black text-sm font-bold rounded-full hover:bg-yellow-400 transition">Profile</button>
+                {profileDropdown && (
+                    <div className="z-[9999] flex flex-col space-y-2 max-w-[200px] w-full min-w-[180px]">
+                        <div className="bg-yellow-500/10 rounded-lg px-2 border border-yellow-600/75 w-full flex flex-col items-start justify-start space-y-0 divide-y divide-yellow-600/50">
+                            <div className="w-full items-center justify-between flex flex-row space-x-4 py-1.5">
+                                <div className="flex flex-row items-center justify-start space-x-2">
+                                    <CircleStackIcon className="w-3 h-3 text-yellow-500" />
+                                    <span className="text-yellow-500 text-xs font-normal">1,234</span>
+                                </div>
+                                <span className="text-white text-[10px] text-center font-bold">Total Flips</span>
+                            </div>
+                            <div className="w-full items-center justify-between flex flex-row space-x-4 py-1.5">
+                                <div className="flex flex-row items-center justify-start space-x-2">
+                                    <CurrencyDollarIcon className="w-3 h-3 text-yellow-500" />
+                                <span className="text-yellow-500 text-xs font-normal">$12,345.67</span>
+                                </div>
+                                <span className="text-white text-[10px] text-center font-bold">Total Winnings</span>
+                            </div>
+                            <div className="w-full items-center justify-between flex flex-row space-x-4 py-1.5">
+                                <div className="flex flex-row items-center justify-start space-x-2">
+                                    <UsersIcon className="w-3 h-3 text-yellow-500" />
+                                <span className="text-yellow-500 text-xs font-normal">567</span>
+                                </div>
+                                <span className="text-white text-[10px] text-center font-bold">Active Users</span>
+                            </div>
+                        </div>
+                        <ul className="w-full flex flex-col -space-y-0.5">
+                        {PROFILE_LINKS.map((link, index) => (
+                        <Link href={link.href} className="w-full py-2 px-4 border border-[#999] cursor-pointer shadow-sm drop-shadow flex flex-row space-x-2 justify-between items-center rounded-md bg-[#fefefe]">
+                            <span className="font-semibold text-sm text-[#333]">{link.name}</span>
+                            <ChevronRightIcon className="w-4 h-4 text-[#000]"/>
+                        </Link>
+                        ))}
+                        </ul>
+                    </div>
+                )}
+            </div>
             <div className="relative text-center p-4 space-y-6 -z-5 w-full flex flex-col justify-center items-center gap-4">
                 {/* User name  */}
                 <div className='flex justify-center h-4 text-white text-4xl'>

--- a/packages/nextjs/components/Header.tsx
+++ b/packages/nextjs/components/Header.tsx
@@ -3,7 +3,7 @@
 import React, { useCallback, useRef, useState, useEffect } from "react";
 import Image from "next/image";
 import Link from "next/link";
-import { Bars3Icon, CircleStackIcon, UserIcon } from "@heroicons/react/24/outline";
+import { Bars3Icon, CircleStackIcon, ChartBarIcon, UserIcon } from "@heroicons/react/24/outline";
 import { useOutsideClick } from "~~/hooks/scaffold-stark";
 import { CustomConnectButton } from "~~/components/scaffold-stark/CustomConnectButton";
 import { usePathname } from "next/navigation";
@@ -29,6 +29,11 @@ export const menuLinks: HeaderMenuLink[] = [
     label: "My Recentflips",
     href: "/recentflips",
     icon: <CircleStackIcon className="h-4 w-4" />,
+  },
+  {
+    label: "Leaderboard",
+    href: "/leaderboard",
+    icon: <ChartBarIcon className="h-4 w-4" />,
   },
   {
     label: "Profile",

--- a/packages/nextjs/styles/globals.css
+++ b/packages/nextjs/styles/globals.css
@@ -134,7 +134,7 @@ p {
 }
 
 .recentflip{
-  background: var(--Schemes-Surface-Container-High, rgba(236, 230, 240, 1));
+  background: var(--Schemes-Surface-Container-High, hsl(276, 25%, 92%));
   
   top: 169px;
   left: 248px;


### PR DESCRIPTION
Issue #47 
- Leaderboard is added to the navbar and redirected to /leaderboard where the required ui designs is implemented using the design approach and pattern of the prooject
![1](https://github.com/user-attachments/assets/f138e13f-194e-437a-9071-36c6b400fa79)

![2](https://github.com/user-attachments/assets/9c62fe3e-7032-410c-a40f-3b52e45cc27f)

- The profile dropdown now features a leaderboard entry that redirects to /leaderboard as well as a Live stat card showing Total Flips, Total Winnings and Active Users 
![3](https://github.com/user-attachments/assets/1e8f17fa-83f7-4cd4-bfd3-789b02a7e095)

