### PR TITLE
feat: Implement navigation using router in Leaderboard and RecentFlip…

### DIFF
--- a/packages/nextjs/app/leaderboard/_components/Leaderboard.tsx
+++ b/packages/nextjs/app/leaderboard/_components/Leaderboard.tsx
@@ -1,144 +1,128 @@
 "use client";
 import Image from "next/image";
-import {
-  CONNECTED_USERS,
-  LEADERBOARD,
-  LIVE_STATS,
-} from "~~/app/assets/constants";
+import { CONNECTED_USERS, LEADERBOARD, LIVE_STATS } from "~~/app/assets/constants";
+import { useRouter } from "next/navigation";
 
 export default function Leaderboard() {
-  const handleButtonClick = () => {
-    console.log("GO BACK");
-  };
-  const handleRefreshClick = () => {
-    console.log("Refresh");
-  };
+	const router = useRouter();
+	const handleButtonClick = () => {
+		router.back();
+	};
+	const handleRefreshClick = () => {
+		console.log("Refresh");
+	};
 
-  return (
-    <div className="relative flex justify-center items-center min-h-screen overflow-hidden w-full p-8 sm:p-12">
-      <div className="w-full grid grid-cols-12 gap-y-12 gap-x-0 md:gap-8 max-w-6xl">
-        {/* Leaderboard */}
-        <div className="w-auto md:w-full col-span-12 md:col-span-6 h-auto bg-[#ece6f0] rounded-[28px] py-[24px] px-[16px] lg:px-[24px]">
-          <h2 className="text-2xl mb-10 w-full text-gray-800">LEADERBOARD</h2>
-          <div className="space-y-1">
-            {LEADERBOARD.map((leaderboard, index) => (
-              <div
-                key={index}
-                className={`flex items-center justify-between pb-1  ${index < (LEADERBOARD as unknown as Array<any>).length - 1 ? "border-b border-gray-400 " : ""}`}
-              >
-                <div className="flex items-center gap-2">
-                  <div className="relative w-8 h-8 flex-none">
-                    <Image
-                      alt={leaderboard.imageAlt}
-                      src={leaderboard.imageSrc}
-                      className="object-contain rounded-full border border-yellow-500/50"
-                      fill
-                    />
-                  </div>
+	return (
+		<div className="relative flex justify-center items-center min-h-screen overflow-hidden w-full p-8 sm:p-12">
+			<div className="w-full grid grid-cols-12 gap-y-12 gap-x-0 md:gap-8 max-w-6xl">
+				{/* Leaderboard */}
+				<div className="w-auto md:w-full col-span-12 md:col-span-6 h-auto bg-[#ece6f0] rounded-[28px] py-[24px] px-[16px] lg:px-[24px]">
+					<h2 className="text-2xl mb-10 w-full text-gray-800">LEADERBOARD</h2>
+					<div className="space-y-1">
+						{LEADERBOARD.map((leaderboard, index) => (
+							<div
+								key={index}
+								className={`flex items-center justify-between pb-1  ${index < (LEADERBOARD as unknown as Array<any>).length - 1 ? "border-b border-gray-400 " : ""}`}>
+								<div className="flex items-center gap-2">
+									<div className="relative w-8 h-8 flex-none">
+										<Image
+											alt={leaderboard.imageAlt}
+											src={leaderboard.imageSrc}
+											className="object-contain rounded-full border border-yellow-500/50"
+											fill
+										/>
+									</div>
 
-                  <p className="text-gray-800 text-sm sm:text-md md:text-sm lg:text-md">
-                    <span className="font-bold">{leaderboard.username}</span>
-                    {" has won"}
-                    <span className="font-bold"> {leaderboard.amount}</span>
-                    {" STRK"}
-                  </p>
-                </div>
-                <p className="text-[#333] text-xs">
-                  {leaderboard.time} minutes ago
-                </p>
-              </div>
-            ))}
-          </div>
-          <div className="mt-5 flex justify-end w-full">
-            <button
-              className="w-auto py-3 px-8 bg-yellow-500 text-black font-bold rounded-lg hover:bg-yellow-400 transition"
-              onClick={handleRefreshClick}
-            >
-              REFRESH
-            </button>
-          </div>
-        </div>
-        {/* Live Stats */}
-        <div className="w-auto md:w-full col-span-12 md:col-span-6 h-auto bg-[#ece6f0] rounded-[28px] py-[24px] px-[16px] lg:px-[24px]">
-          <h2 className="text-2xl mb-10 w-full text-gray-800">LIVE STATS</h2>
-          <div className="space-y-1">
-            {LIVE_STATS.map((livestat, index) => (
-              <div
-                key={index}
-                className={`flex items-center justify-between pb-1  ${index < (LIVE_STATS as unknown as Array<any>).length - 1 ? "border-b border-gray-400 " : ""}`}
-              >
-                <div className="flex items-center gap-2">
-                  <div className="relative w-8 h-8 flex-none">
-                    <Image
-                      alt={livestat.imageAlt}
-                      src={livestat.imageSrc}
-                      className="object-contain rounded-full border border-yellow-500/50"
-                      fill
-                    />
-                  </div>
-                  <p className="text-gray-800 text-sm sm:text-md md:text-sm lg:text-md">
-                    <span className="font-bold">{livestat.username}</span>
-                    {" just played"}
-                    <span className="font-bold"> {livestat.amount}</span>
-                    {" STRK"}
-                  </p>
-                </div>
-                <p className="text-[#333] text-xs">
-                  {livestat.time} minutes ago
-                </p>
-              </div>
-            ))}
-          </div>
-          <div className="mt-5 flex justify-end w-full">
-            <button
-              className="w-auto py-3 px-8 bg-yellow-500 text-black font-bold rounded-lg hover:bg-yellow-400 transition"
-              onClick={handleRefreshClick}
-            >
-              REFRESH
-            </button>
-          </div>
-        </div>
-        {/* Connected Users */}
-        <div className="w-full md:col-start-3 md:col-end-11 col-span-12 md:col-span-8 h-auto bg-[#ece6f0] rounded-[28px] py-[24px] px-[16px] lg:px-[24px]">
-          <h2 className="text-2xl mb-10 w-full text-gray-800">
-            CONNECTED USERS
-          </h2>
-          <div className="space-y-1">
-            {CONNECTED_USERS.map((connected_user, index) => (
-              <div
-                key={index}
-                className={`flex items-center justify-between pb-1  ${index < (CONNECTED_USERS as unknown as Array<any>).length - 1 ? "border-b border-gray-400 " : ""}`}
-              >
-                <div className="flex items-center gap-2">
-                  <div className="relative w-8 h-8 flex-none">
-                    <Image
-                      alt={connected_user.imageAlt}
-                      src={connected_user.imageSrc}
-                      className="object-contain rounded-full border border-yellow-500/50"
-                      fill
-                    />
-                  </div>
-                  <p className="text-gray-800 text-sm sm:text-md md:text-sm lg:text-md">
-                    <span className="font-bold">{connected_user.username}</span>
-                    {" is live"}
-                  </p>
-                </div>
-                <p className="text-[#333] text-xs">
-                  {connected_user.time} minutes ago
-                </p>
-              </div>
-            ))}
-          </div>
-          <div className="mt-5 flex justify-end w-full">
-            <button
-              className="w-full py-3 px-8 bg-yellow-500 text-black font-bold rounded-lg hover:bg-yellow-400 transition"
-              onClick={handleButtonClick}
-            >
-              GO BACK
-            </button>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
+									<p className="text-gray-800 text-sm sm:text-md md:text-sm lg:text-md">
+										<span className="font-bold">{leaderboard.username}</span>
+										{" has won"}
+										<span className="font-bold"> {leaderboard.amount}</span>
+										{" STRK"}
+									</p>
+								</div>
+								<p className="text-[#333] text-xs">{leaderboard.time} minutes ago</p>
+							</div>
+						))}
+					</div>
+					<div className="mt-5 flex justify-end w-full">
+						<button
+							className="w-auto py-3 px-8 bg-yellow-500 text-black font-bold rounded-lg hover:bg-yellow-400 transition"
+							onClick={handleRefreshClick}>
+							REFRESH
+						</button>
+					</div>
+				</div>
+				{/* Live Stats */}
+				<div className="w-auto md:w-full col-span-12 md:col-span-6 h-auto bg-[#ece6f0] rounded-[28px] py-[24px] px-[16px] lg:px-[24px]">
+					<h2 className="text-2xl mb-10 w-full text-gray-800">LIVE STATS</h2>
+					<div className="space-y-1">
+						{LIVE_STATS.map((livestat, index) => (
+							<div
+								key={index}
+								className={`flex items-center justify-between pb-1  ${index < (LIVE_STATS as unknown as Array<any>).length - 1 ? "border-b border-gray-400 " : ""}`}>
+								<div className="flex items-center gap-2">
+									<div className="relative w-8 h-8 flex-none">
+										<Image
+											alt={livestat.imageAlt}
+											src={livestat.imageSrc}
+											className="object-contain rounded-full border border-yellow-500/50"
+											fill
+										/>
+									</div>
+									<p className="text-gray-800 text-sm sm:text-md md:text-sm lg:text-md">
+										<span className="font-bold">{livestat.username}</span>
+										{" just played"}
+										<span className="font-bold"> {livestat.amount}</span>
+										{" STRK"}
+									</p>
+								</div>
+								<p className="text-[#333] text-xs">{livestat.time} minutes ago</p>
+							</div>
+						))}
+					</div>
+					<div className="mt-5 flex justify-end w-full">
+						<button
+							className="w-auto py-3 px-8 bg-yellow-500 text-black font-bold rounded-lg hover:bg-yellow-400 transition"
+							onClick={handleRefreshClick}>
+							REFRESH
+						</button>
+					</div>
+				</div>
+				{/* Connected Users */}
+				<div className="w-full md:col-start-3 md:col-end-11 col-span-12 md:col-span-8 h-auto bg-[#ece6f0] rounded-[28px] py-[24px] px-[16px] lg:px-[24px]">
+					<h2 className="text-2xl mb-10 w-full text-gray-800">CONNECTED USERS</h2>
+					<div className="space-y-1">
+						{CONNECTED_USERS.map((connected_user, index) => (
+							<div
+								key={index}
+								className={`flex items-center justify-between pb-1  ${index < (CONNECTED_USERS as unknown as Array<any>).length - 1 ? "border-b border-gray-400 " : ""}`}>
+								<div className="flex items-center gap-2">
+									<div className="relative w-8 h-8 flex-none">
+										<Image
+											alt={connected_user.imageAlt}
+											src={connected_user.imageSrc}
+											className="object-contain rounded-full border border-yellow-500/50"
+											fill
+										/>
+									</div>
+									<p className="text-gray-800 text-sm sm:text-md md:text-sm lg:text-md">
+										<span className="font-bold">{connected_user.username}</span>
+										{" is live"}
+									</p>
+								</div>
+								<p className="text-[#333] text-xs">{connected_user.time} minutes ago</p>
+							</div>
+						))}
+					</div>
+					<div className="mt-5 flex justify-end w-full">
+						<button
+							className="w-full py-3 px-8 bg-yellow-500 text-black font-bold rounded-lg hover:bg-yellow-400 transition"
+							onClick={handleButtonClick}>
+							GO BACK
+						</button>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
 }

--- a/packages/nextjs/app/recentflips/_components/RecentFlip.tsx
+++ b/packages/nextjs/app/recentflips/_components/RecentFlip.tsx
@@ -1,53 +1,49 @@
 "use client";
 import Image from "next/image";
 import { MY_FLIPS } from "~~/app/assets/constants";
-
+import { useRouter } from "next/navigation";
 
 export default function RecentFlip() {
-  const handleButtonClick = () => {
-    console.log("GO BACK button clicked");
-  };
+	const router = useRouter();
+	const handleButtonClick = () => {
+		router.back();
+	};
 
-  return (
-    <div className="relative flex justify-center items-center min-h-screen">
-      <div className="recentflip w-[40%] max-w-[560px] min-w-[280px] h-auto">
-      <h2 className="text-2xl mb-10 w-full text-gray-800">MY RECENT FLIPS</h2>
-        <div className="space-y-1">
-          {MY_FLIPS.map((flip, index) => (
-            <div
-              key={index}
-              className={`flex items-center justify-between pb-1  ${index < 2 ? "border-b border-gray-400 " : ""}`}
-            >
-              <div className="flex items-center gap-4">
-                <div className="relative w-12 h-[51px]">
-                  <Image
-                    alt={flip.imageAlt}
-                    src={flip.imageSrc}
-                    className="object-contain"
-                    fill
-                  />
-                </div>
+	return (
+		<div className="relative flex justify-center items-center min-h-screen">
+			<div className="recentflip w-[40%] max-w-[560px] min-w-[280px] h-auto">
+				<h2 className="text-2xl mb-10 w-full text-gray-800">MY RECENT FLIPS</h2>
+				<div className="space-y-1">
+					{MY_FLIPS.map((flip, index) => (
+						<div
+							key={index}
+							className={`flex items-center justify-between pb-1  ${index < 2 ? "border-b border-gray-400 " : ""}`}>
+							<div className="flex items-center gap-4">
+								<div className="relative w-12 h-[51px]">
+									<Image
+										alt={flip.imageAlt}
+										src={flip.imageSrc}
+										className="object-contain"
+										fill
+									/>
+								</div>
 
-                <p className="text-gray-800">
-                  <span className="font-bold">
-                    {flip.description.split(" ")[0]}
-                  </span>{" "}
-                  {flip.description.split(" ").slice(1).join(" ")}
-                </p>
-              </div>
-              <p className="text-[#333] text-xs">{flip.time} minutes ago</p>
-            </div>
-          ))}
-        </div>
-        <div className="mt-5 mb-5 ">
-          <button
-            className="w-full py-3 bg-yellow-500 text-black font-bold rounded-lg hover:bg-yellow-400 transition"
-            onClick={handleButtonClick}
-          >
-            GO BACK
-          </button>
-        </div>
-      </div>
-    </div>
-  );
+								<p className="text-gray-800">
+									<span className="font-bold">{flip.description.split(" ")[0]}</span> {flip.description.split(" ").slice(1).join(" ")}
+								</p>
+							</div>
+							<p className="text-[#333] text-xs">{flip.time} minutes ago</p>
+						</div>
+					))}
+				</div>
+				<div className="mt-5 mb-5 ">
+					<button
+						className="w-full py-3 bg-yellow-500 text-black font-bold rounded-lg hover:bg-yellow-400 transition"
+						onClick={handleButtonClick}>
+						GO BACK
+					</button>
+				</div>
+			</div>
+		</div>
+	);
 }


### PR DESCRIPTION
## Implement GoBack Functionality for RecentFlips and Leaderboard Pages


## Description
This pull request introduces the "Go Back" functionality for the RecentFlips and Leaderboard components. The changes ensure that users can navigate back to the previous page seamlessly using the "GO BACK" button.

## Related Issues
Closes #105 

## Changes Made
- Implemented the `handleButtonClick` function in the RecentFlip component to navigate back using the router.
- Implemented the `handleButtonClick` function in the Leaderboard component to navigate back using the router.


## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] Documentation has been updated accordingly

## Screenshots
<img width="1381" alt="Screenshot 2025-02-21 at 02 50 45" src="https://github.com/user-attachments/assets/050a16d5-0384-461e-bf30-687e6581226c" />
<img width="1381" alt="Screenshot 2025-02-21 at 02 51 59" src="https://github.com/user-attachments/assets/6769b99e-9656-4512-9014-069d846edd25" />
