### PR TITLE
Feat: Update path from Transaction History

### DIFF
--- a/packages/nextjs/components/scaffold-stark/CustomConnectButton/AddressInfoDropdown.tsx
+++ b/packages/nextjs/components/scaffold-stark/CustomConnectButton/AddressInfoDropdown.tsx
@@ -115,11 +115,11 @@ export const AddressInfoDropdown = ({
             <button
               className="btn-sm !rounded-xl flex gap-3 py-3"
               onClick={() => {
-                window.location.href = "/transaction-history";
+                window.location.href = "/history";
               }}
             >
               <ArrowsRightLeftIcon className="h-6 w-4 ml-2 sm:ml-0" />
-              <span className="whitespace-nowrap">Transaction history</span>
+              <span className="whitespace-nowrap">Transaction History</span>
             </button>
           </li>
           <li className={selectingNetwork ? "hidden" : ""}>


### PR DESCRIPTION
## Update path from Transaction History

## Description
* Corrected the path for accessing the transaction history page from ´/transaction-history´  to ´/history´.
* Updated the label text by capitalizing "H" in "Transaction History" for consistency with proper capitalization.

## Related Issues
Closes #104 

## Changes Made

- [x] Updated path
- [x] Updated label


## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] Documentation has been updated accordingly

## Screenshots

<img width="229" alt="image" src="https://github.com/user-attachments/assets/16bd1e6c-31a5-4009-9541-dfdd52e3426d" />
