### PR TITLE
docs: add contributors section in readme

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,12 @@
+{
+  "projectName": "nombre-del-proyecto",
+  "projectOwner": "nombre-organizacion-o-usuario",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "files": ["README.md"],
+  "imageSize": 100,
+  "commit": false,
+  "commitConvention": "none",
+  "contributors": [],
+  "contributorsPerLine": 7
+}

--- a/README.md
+++ b/README.md
@@ -71,4 +71,14 @@ yarn start
 3. Commit your changes and push to your fork.
 4. Open a pull request to the main repository.
 
+## Contributors ✨
+
+Thanks goes to these wonderful people:
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+<!-- ALL-CONTRIBUTORS-LIST:END -->
 ---


### PR DESCRIPTION
## Pull Request Title
Add contributors section in readme

## Description
I put the contributors section in your readme file.

Usually it use a bot (allcontributors) for this task, you can read all instructions in https://allcontributors.org/docs/es-es/bot/usage.

If you want to test you need to install the bot in your repository: https://allcontributors.org/docs/en/bot/installation
Then, you can write a comment on an issue or PR the next command: 

@all-contributors please add @davidmelendez for infrastructure, tests and code

where @davidmelendez is the name user of contributor, and [infrastructure, tests and code] is a list of valid contribution types that you can looking in the next page: https://allcontributors.org/docs/en/emoji-key

![image](https://github.com/user-attachments/assets/d5c4eec6-b9d2-4525-bea2-0f4fa55c20f3)


## Related Issues
Closes #102 

## Changes Made
- [X] List major changes
- [X] Highlight important updates
- [X] Describe any breaking changes (if applicable)
- [X] New and existing unit tests pass locally with my changes

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] Documentation has been updated accordingly

## Screenshots
This Screenshots is from a test project in my github because i can not to invoke the bot in your project

![image](https://github.com/user-attachments/assets/76e6610f-f0a2-4cc0-b43b-3d1f91657ac0)

## Additional Notes
